### PR TITLE
fix (build.gradle.kts) - allow to be installed in IDE 2023.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ tasks {
     patchPluginXml {
         version.set("${project.version}")
         sinceBuild.set("221")
-        untilBuild.set("231.*")
+        untilBuild.set("232.*")
     }
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {


### PR DESCRIPTION
Same issue as we had with 2023.1 https://github.com/mikinw/TabMover/pull/5